### PR TITLE
make_deb modified to build only on armhf architecture

### DIFF
--- a/make_deb
+++ b/make_deb
@@ -56,6 +56,11 @@ do
   esac
 done
 
+if [ "$(dpkg --print-architecture)" != "armhf" ]; then
+  echo "Package building is only supported on armhf architecture!!"
+  exit 0
+fi
+
 architecture="armhf"
 version=`cat ${GIT_ROOT}/VERSION.south.sensehat | tr -d ' ' | grep 'foglamp_south_sensehat_version=' | head -1 | sed -e 's/\(.*\)=\(.*\)/\2/g'`
 foglamp_version=`cat ${GIT_ROOT}/VERSION.south.sensehat | tr -d ' ' | grep 'foglamp_version' | head -1 | sed -e 's/\(.*\)version\(.*\)/\2/g'`


### PR DESCRIPTION
**Changes:**

1. For FOGL-2004: Create debian on armhf architecture only. 

**Note:**
Although this plugin can be built on any architecture but since the target platform is armhf only, we are constraining it to build on the same to make the behaviour consistent across all plugins. 